### PR TITLE
LDOP-298 traefik setup

### DIFF
--- a/jenkinsfiles/create
+++ b/jenkinsfiles/create
@@ -14,17 +14,17 @@ pipeline {
                     accessKeyVariable: "AWS_ACCESS_KEY_ID",
                     secretKeyVariable: "AWS_SECRET_ACCESS_KEY"]]) {
 
-                    slackSend (channel: "#LDOP-298", color: "#3AA552", message: "Beginning Terraform pipeline for:\n${env.GIT_COMMIT}.\n${env.JOB_URL}")
+                    slackSend (channel: "#ldop", color: "#3AA552", message: "Beginning Terraform pipeline for:\n${env.GIT_COMMIT}.\n${env.JOB_URL}")
                     sh 'terraform init'
                     sh 'terraform validate'
                 }
             }
             post {
                 success {
-                    slackSend (channel: "#LDOP-298", color: "#3AA552", message: "Terraform validation succeeded.\n${env.JOB_URL}")
+                    slackSend (channel: "#ldop", color: "#3AA552", message: "Terraform validation succeeded.\n${env.JOB_URL}")
                 }
                 failure {
-                    slackSend (channel: "#LDOP-298", color: "#CF1318", message: "Terraform validation failed.\n${env.JOB_URL}")
+                    slackSend (channel: "#ldop", color: "#CF1318", message: "Terraform validation failed.\n${env.JOB_URL}")
                 }
             }
         }
@@ -41,10 +41,10 @@ pipeline {
             }
             post {
                 success {
-                    slackSend (channel: "#LDOP-298", color: "#3AA552", message: "Terraform plan was successful.\n${env.JOB_URL}")
+                    slackSend (channel: "#ldop", color: "#3AA552", message: "Terraform plan was successful.\n${env.JOB_URL}")
                 }
                 failure {
-                    slackSend (channel: "#LDOP-298", color: "#CF1318", message: "Terraform plan failed.\n${env.JOB_URL}")
+                    slackSend (channel: "#ldop", color: "#CF1318", message: "Terraform plan failed.\n${env.JOB_URL}")
                 }
             }
         }
@@ -59,17 +59,17 @@ pipeline {
                     accessKeyVariable: "AWS_ACCESS_KEY_ID",
                     secretKeyVariable: "AWS_SECRET_ACCESS_KEY"]]) {
 
-                    slackSend (channel: "#LDOP-298", color: "#FFA500", message: "Terraform needs permission to continue.\n${env.JOB_URL}")
+                    slackSend (channel: "#ldop", color: "#FFA500", message: "Terraform needs permission to continue.\n${env.JOB_URL}")
                     input 'Apply changes?'
                     sh 'terraform apply'
                 }
             }
             post {
                 success {
-                    slackSend (channel: "#LDOP-298", color: "#3AA552", message: "Production instance successfully launched.\n${env.JOB_URL}")
+                    slackSend (channel: "#ldop", color: "#3AA552", message: "Production instance successfully launched.\n${env.JOB_URL}")
                 }
                 failure {
-                    slackSend (channel: "#LDOP-298", color: "#CF1318", message: "Production instance failed to launch.\n${env.JOB_URL}")
+                    slackSend (channel: "#ldop", color: "#CF1318", message: "Production instance failed to launch.\n${env.JOB_URL}")
                 }
             }
         }

--- a/jenkinsfiles/create
+++ b/jenkinsfiles/create
@@ -1,4 +1,3 @@
-
 pipeline {
     agent {
       docker {
@@ -15,17 +14,17 @@ pipeline {
                     accessKeyVariable: "AWS_ACCESS_KEY_ID",
                     secretKeyVariable: "AWS_SECRET_ACCESS_KEY"]]) {
 
-                    slackSend (channel: "#ldop", color: "#3AA552", message: "Beginning Terraform pipeline for:\n${env.GIT_COMMIT}.\n${env.JOB_URL}")
+                    slackSend (channel: "#LDOP-298", color: "#3AA552", message: "Beginning Terraform pipeline for:\n${env.GIT_COMMIT}.\n${env.JOB_URL}")
                     sh 'terraform init'
                     sh 'terraform validate'
                 }
             }
             post {
                 success {
-                    slackSend (channel: "#ldop", color: "#3AA552", message: "Terraform validation succeeded.\n${env.JOB_URL}")
+                    slackSend (channel: "#LDOP-298", color: "#3AA552", message: "Terraform validation succeeded.\n${env.JOB_URL}")
                 }
                 failure {
-                    slackSend (channel: "#ldop", color: "#CF1318", message: "Terraform validation failed.\n${env.JOB_URL}")
+                    slackSend (channel: "#LDOP-298", color: "#CF1318", message: "Terraform validation failed.\n${env.JOB_URL}")
                 }
             }
         }
@@ -42,10 +41,10 @@ pipeline {
             }
             post {
                 success {
-                    slackSend (channel: "#ldop", color: "#3AA552", message: "Terraform plan was successful.\n${env.JOB_URL}")
+                    slackSend (channel: "#LDOP-298", color: "#3AA552", message: "Terraform plan was successful.\n${env.JOB_URL}")
                 }
                 failure {
-                    slackSend (channel: "#ldop", color: "#CF1318", message: "Terraform plan failed.\n${env.JOB_URL}")
+                    slackSend (channel: "#LDOP-298", color: "#CF1318", message: "Terraform plan failed.\n${env.JOB_URL}")
                 }
             }
         }
@@ -60,17 +59,17 @@ pipeline {
                     accessKeyVariable: "AWS_ACCESS_KEY_ID",
                     secretKeyVariable: "AWS_SECRET_ACCESS_KEY"]]) {
 
-                    slackSend (channel: "#ldop", color: "#FFA500", message: "Terraform needs permission to continue.\n${env.JOB_URL}")
+                    slackSend (channel: "#LDOP-298", color: "#FFA500", message: "Terraform needs permission to continue.\n${env.JOB_URL}")
                     input 'Apply changes?'
                     sh 'terraform apply'
                 }
             }
             post {
                 success {
-                    slackSend (channel: "#ldop", color: "#3AA552", message: "Production instance successfully launched.\n${env.JOB_URL}")
+                    slackSend (channel: "#LDOP-298", color: "#3AA552", message: "Production instance successfully launched.\n${env.JOB_URL}")
                 }
                 failure {
-                    slackSend (channel: "#ldop", color: "#CF1318", message: "Production instance failed to launch.\n${env.JOB_URL}")
+                    slackSend (channel: "#LDOP-298", color: "#CF1318", message: "Production instance failed to launch.\n${env.JOB_URL}")
                 }
             }
         }

--- a/jenkinsfiles/destroy
+++ b/jenkinsfiles/destroy
@@ -1,7 +1,4 @@
 pipeline {
-    triggers {
-      /* none */
-    }
     agent {
       docker {
         image "hashicorp/terraform:latest"
@@ -18,6 +15,7 @@ pipeline {
                     secretKeyVariable: "AWS_SECRET_ACCESS_KEY"]]) {
                     slackSend (channel: "#ldop", color: "#FFA500", message: "Terraform needs permission to continue.\n${env.JOB_URL}")
                     input 'Destroy resources?'
+                    sh 'terraform init'
                     sh 'terraform destroy -force'
                 }
             }

--- a/launch-traefik.sh
+++ b/launch-traefik.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+docker run -d -v /var/run/docker.sock:/var/run/docker.sock:ro \
+  -v /home/ec2-user/traefik.toml:/etc/traefik/traefik.toml:ro \
+  -v /home/ec2-user/acme:/etc/traefik/acme -p 80:80 -p 443:443 \
+  -p 8080:8080 --name traefik traefik 

--- a/petclinic.tf
+++ b/petclinic.tf
@@ -57,7 +57,7 @@ resource "aws_instance" "qa" {
   vpc_security_group_ids = ["${aws_security_group.web.id}"]
 
   tags {
-    Name = "qa-petclinicliatr.io"
+    Name = "qa-petclinic.liatr.io"
   }
 
   provisioner "remote-exec" {

--- a/petclinic.tf
+++ b/petclinic.tf
@@ -30,7 +30,7 @@ resource "aws_security_group" "web" {
 }
 
 resource "aws_instance" "dev" {
-  ami                    = "${data.aws_ami.latest_ami.id}" # Amazon Linux
+  ami                    = "${data.aws_ami.latest_ami.id}"  # Amazon Linux
   instance_type          = "t2.micro"
   key_name               = "${var.aws_key_pair}"
   vpc_security_group_ids = ["${aws_security_group.web.id}"]
@@ -48,10 +48,31 @@ resource "aws_instance" "dev" {
       private_key = "${file("${var.private_key_path}")}"
     }
   }
+
+  provisioner "file" {
+    source      = "./traefik.toml"
+    destination = "/home/ec2-user/traefik.toml"
+
+    connection {
+      type        = "ssh"
+      user        = "ec2-user"
+      private_key = "${file("${var.private_key_path}")}"
+    }
+  }
+
+  provisioner "remote-exec" {
+    script = "${path.module}/launch-traefik.sh"
+
+    connection {
+      type        = "ssh"
+      user        = "ec2-user"
+      private_key = "${file("${var.private_key_path}")}"
+    }
+  }
 }
 
 resource "aws_instance" "qa" {
-  ami                    = "${data.aws_ami.latest_ami.id}" # Amazon Linux
+  ami                    = "${data.aws_ami.latest_ami.id}"  # Amazon Linux
   instance_type          = "t2.micro"
   key_name               = "${var.aws_key_pair}"
   vpc_security_group_ids = ["${aws_security_group.web.id}"]
@@ -69,10 +90,31 @@ resource "aws_instance" "qa" {
       private_key = "${file("${var.private_key_path}")}"
     }
   }
+
+  provisioner "file" {
+    source      = "./traefik.toml"
+    destination = "/home/ec2-user/traefik.toml"
+
+    connection {
+      type        = "ssh"
+      user        = "ec2-user"
+      private_key = "${file("${var.private_key_path}")}"
+    }
+  }
+
+  provisioner "remote-exec" {
+    script = "${path.module}/launch-traefik.sh"
+
+    connection {
+      type        = "ssh"
+      user        = "ec2-user"
+      private_key = "${file("${var.private_key_path}")}"
+    }
+  }
 }
 
 resource "aws_instance" "prod" {
-  ami                    = "${data.aws_ami.latest_ami.id}" # Amazon Linux
+  ami                    = "${data.aws_ami.latest_ami.id}"  # Amazon Linux
   instance_type          = "t2.micro"
   key_name               = "${var.aws_key_pair}"
   vpc_security_group_ids = ["${aws_security_group.web.id}"]
@@ -83,6 +125,27 @@ resource "aws_instance" "prod" {
 
   provisioner "remote-exec" {
     script = "${path.module}/provision.sh"
+
+    connection {
+      type        = "ssh"
+      user        = "ec2-user"
+      private_key = "${file("${var.private_key_path}")}"
+    }
+  }
+
+  provisioner "file" {
+    source      = "./traefik.toml"
+    destination = "/home/ec2-user/traefik.toml"
+
+    connection {
+      type        = "ssh"
+      user        = "ec2-user"
+      private_key = "${file("${var.private_key_path}")}"
+    }
+  }
+
+  provisioner "remote-exec" {
+    script = "${path.module}/launch-traefik.sh"
 
     connection {
       type        = "ssh"

--- a/petclinic.tf
+++ b/petclinic.tf
@@ -14,8 +14,8 @@ resource "aws_security_group" "web" {
   }
 
   ingress {
-    from_port   = 80
-    to_port     = 80
+    from_port   = 443
+    to_port     = 443
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
@@ -173,7 +173,23 @@ resource "aws_route53_record" "qa" {
 
 resource "aws_route53_record" "prod" {
   zone_id = "${data.aws_route53_zone.liatrio.zone_id}"
-  name    = "prod-petclinic.liatr.io"
+  name    = "petclinic.liatr.io"
+  type    = "A"
+  ttl     = 300
+  records = ["${aws_instance.prod.public_ip}"]
+}
+
+resource "aws_route53_record" "prod-1" {
+  zone_id = "${data.aws_route53_zone.liatrio.zone_id}"
+  name    = "petclinic-1.liatr.io"
+  type    = "A"
+  ttl     = 300
+  records = ["${aws_instance.prod.public_ip}"]
+}
+
+resource "aws_route53_record" "prod-2" {
+  zone_id = "${data.aws_route53_zone.liatrio.zone_id}"
+  name    = "petclinic-2.liatr.io"
   type    = "A"
   ttl     = 300
   records = ["${aws_instance.prod.public_ip}"]

--- a/provision.sh
+++ b/provision.sh
@@ -7,3 +7,6 @@ sudo yum install -y docker
 sudo service docker start
 
 sudo usermod -a -G docker ec2-user
+
+mkdir /home/ec2-user/acme
+touch /home/ec2-user/acme/acme.json

--- a/traefik.toml
+++ b/traefik.toml
@@ -20,7 +20,7 @@ address = ":8080"
 [acme]
 # Email address used for registration
 email = "test@traefik.io"
-storageFile = "/home/ec2-user/acme.json"
+storageFile = "/etc/traefik/acme/acme.json"
 entryPoint = "https"
 onDemand = false
 OnHostRule = true

--- a/traefik.toml
+++ b/traefik.toml
@@ -1,0 +1,33 @@
+defaultEntryPoints = ["http", "https"]
+
+[web]
+# Port for the status page
+address = ":8080"
+
+# Entrypoints, http and https
+[entryPoints]
+  # http should be redirected to https
+  [entryPoints.http]
+  address = ":80"
+    [entryPoints.http.redirect]
+    entryPoint = "https"
+  # https is the default
+  [entryPoints.https]
+  address = ":443"
+    [entryPoints.https.tls]
+
+# Enable ACME (Let's Encrypt): automatic SSL
+[acme]
+# Email address used for registration
+email = "test@traefik.io"
+storageFile = "/home/ec2-user/acme.json"
+entryPoint = "https"
+onDemand = false
+OnHostRule = true
+
+# Enable Docker configuration backend
+[docker]
+endpoint = "unix:///var/run/docker.sock"
+domain = "example.com"
+watch = true
+exposedbydefault = false


### PR DESCRIPTION
Adds a Traefik container to each deploy environment. The traefik container is configured to create a verified letsencrypt ssl cert, listens on port 443, and redirects port 80 traffic to port 443. 

With Traefik in place and configured, we are ready to start deploying application containers that configure their own proxy/loadbalancer settings using labels.