### PR TITLE
Added Uptime=critical tag to deploy instances

### DIFF
--- a/petclinic.tf
+++ b/petclinic.tf
@@ -36,7 +36,8 @@ resource "aws_instance" "dev" {
   vpc_security_group_ids = ["${aws_security_group.web.id}"]
 
   tags {
-    Name = "dev-petclinic.liatr.io"
+    Name   = "dev-petclinic.liatr.io"
+    Uptime = "critical"
   }
 
   provisioner "remote-exec" {
@@ -78,7 +79,8 @@ resource "aws_instance" "qa" {
   vpc_security_group_ids = ["${aws_security_group.web.id}"]
 
   tags {
-    Name = "qa-petclinic.liatr.io"
+    Name   = "qa-petclinic.liatr.io"
+    Uptime = "critical"
   }
 
   provisioner "remote-exec" {
@@ -120,7 +122,8 @@ resource "aws_instance" "prod" {
   vpc_security_group_ids = ["${aws_security_group.web.id}"]
 
   tags {
-    Name = "prod-petclinic.liatr.io"
+    Name   = "prod-petclinic.liatr.io"
+    Uptime = "critical"
   }
 
   provisioner "remote-exec" {


### PR DESCRIPTION
Rundeck stops instances without an uptime tag every evening. While we don't necessarily need access to these instances in the evening, stopping instances releases their ip addresses which are configured in Route 53. Adding the Uptime=critical tag will prevent Rundeck from stopping the instances.

Note: If we want scheduled downtime on these instances, we need to find a way to reapply terraform configuration after restarting the instances.