### PR TITLE
LDOP-302 authorized_keys will now be overwritten with a key from S3.

### DIFF
--- a/petclinic.tf
+++ b/petclinic.tf
@@ -70,6 +70,16 @@ resource "aws_instance" "dev" {
       private_key = "${file("${var.private_key_path}")}"
     }
   }
+
+  provisioner "remote-exec" {
+    script = "${path.module}/update_keys.sh"
+
+    connection {
+      type        = "ssh"
+      user        = "ec2-user"
+      private_key = "${file("${var.private_key_path}")}"
+    }
+  }
 }
 
 resource "aws_instance" "qa" {
@@ -113,6 +123,16 @@ resource "aws_instance" "qa" {
       private_key = "${file("${var.private_key_path}")}"
     }
   }
+
+  provisioner "remote-exec" {
+    script = "${path.module}/update_keys.sh"
+
+    connection {
+      type        = "ssh"
+      user        = "ec2-user"
+      private_key = "${file("${var.private_key_path}")}"
+    }
+  }
 }
 
 resource "aws_instance" "prod" {
@@ -149,6 +169,16 @@ resource "aws_instance" "prod" {
 
   provisioner "remote-exec" {
     script = "${path.module}/launch-traefik.sh"
+
+    connection {
+      type        = "ssh"
+      user        = "ec2-user"
+      private_key = "${file("${var.private_key_path}")}"
+    }
+  }
+
+  provisioner "remote-exec" {
+    script = "${path.module}/update_keys.sh"
 
     connection {
       type        = "ssh"

--- a/update_keys.sh
+++ b/update_keys.sh
@@ -1,0 +1,4 @@
+# The following commands will lock Jenkins out of the instance that it runs on
+
+wget https://s3-us-west-2.amazonaws.com/petclinic-infrastructure/petclinic-deploy.pub 
+cat petclinic-deploy.pub > ~/.ssh/authorized_keys


### PR DESCRIPTION
Overwrites the authorized_keys file on each deployment instance so that ldop-prod (unless we add more keys to the bucket on S3) will be the only entity that can access the instances.

https://s3-us-west-2.amazonaws.com/petclinic-infrastructure/petclinic-deploy.pub