### PR TITLE
LDOP-302 Traefik in bridge network.

### DIFF
--- a/launch-traefik.sh
+++ b/launch-traefik.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-docker run -d -v /var/run/docker.sock:/var/run/docker.sock:ro \
+docker run -d --network bridge \
+  -v /var/run/docker.sock:/var/run/docker.sock:ro \
   -v /home/ec2-user/traefik.toml:/etc/traefik/traefik.toml:ro \
   -v /home/ec2-user/acme:/etc/traefik/acme -p 80:80 -p 443:443 \
   -p 8080:8080 --name traefik traefik 


### PR DESCRIPTION
This PR is to have Traefik placed in the bridge network when launched on the deployment environments. This will ensure that Traefik will be able to correctly route other Docker containers that we deploy to the instances.