### PR TITLE
Target groups and default listener

### DIFF
--- a/prod-petclinic.tf
+++ b/prod-petclinic.tf
@@ -123,7 +123,7 @@ resource "aws_instance" "proda" {
   subnet_id                   = "${aws_subnet.proda.id}"
   vpc_security_group_ids      = ["${aws_security_group.prod_webserver.id}"]
   associate_public_ip_address = true
-  availability_zone           = "us-east-1a"
+  availability_zone           = "us-west-2a"
 
   tags {
     Name   = "proda.petclinic.liatr.io"
@@ -169,7 +169,7 @@ resource "aws_instance" "prodb" {
   subnet_id                   = "${aws_subnet.prodb.id}"
   vpc_security_group_ids      = ["${aws_security_group.prod_webserver.id}"]
   associate_public_ip_address = true
-  availability_zone           = "us-east-1b"
+  availability_zone           = "us-west-2b"
 
   tags {
     Name   = "prodb.petclinic.liatr.io"
@@ -209,11 +209,11 @@ resource "aws_instance" "prodb" {
 }
 
 resource "aws_s3_bucket" "prod_alb_log" {
-  bucket = "liatrio_petclinic_access_log"
+  bucket = "liatrio-petclinic-access-log"
   acl    = "private"
 
   tags = {
-    Name = "liatrio_petclinic_access_log"
+    Name = "liatrio-petclinic-access-log"
   }
 }
 

--- a/qa-petclinic.tf
+++ b/qa-petclinic.tf
@@ -20,7 +20,7 @@ resource "aws_instance" "qa" {
   }
 
   provisioner "file" {
-    source      = "./traefik.toml"
+    source      = "./traefik-https.toml"
     destination = "/home/ec2-user/traefik.toml"
 
     connection {


### PR DESCRIPTION
Split the prod-petclinic target group into two target groups (proda-petclinic and prodb-petclinic) to facilitate blue-green deployments. Each target group has only 1 instance for now, but it would be easy to scale up if we wanted to. Also created a default listener that forwards proda-petclinic. 

To perform a blue/green deployment we can delete the attached listener and create a new listener that forwards the other target group.

Also added some bugfixes for a misnamed bucket and incorrect filepaths.